### PR TITLE
fix/opensearch-secret-old_not_found

### DIFF
--- a/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
+++ b/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
@@ -19,7 +19,12 @@ type: Opaque
 data: {{ get $secretObj "data" | toYaml | nindent 2 }}
 {{- else }}
 stringData:
-  username: "{{ (include "opensearch.username" .) }}"
-  password: "{{ (include "opensearch.password" .) }}"
+  {{- if .Values.global.externalOpensearch.enabled }}
+      username: "{{ .Values.global.externalOpensearch.username }}"
+      password: "{{ .Values.global.externalOpensearch.password }}"
+  {{- else }}
+      username: "{{ (include "opensearch.username" .) }}"
+      password: "{{ (include "opensearch.password" .) }}"
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
+++ b/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
@@ -1,6 +1,5 @@
 # This secret is used for changing OpenSearch credentials. It is created by Helm, but all updates are performed by operator.
 # If `opensearch-secret` secret exists, data is taken from it, otherwise, from `.Values` parameters.
-
 {{- $secretName := printf "%s-secret-old" (include "opensearch.fullname" .) }}
 {{- if not (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "opensearch.fullname" .))) | default dict }}

--- a/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
+++ b/charts/helm/opensearch-service/templates/opensearch/secret-old.yaml
@@ -1,6 +1,6 @@
 # This secret is used for changing OpenSearch credentials. It is created by Helm, but all updates are performed by operator.
 # If `opensearch-secret` secret exists, data is taken from it, otherwise, from `.Values` parameters.
-{{- if not .Values.global.externalOpensearch.enabled }}
+
 {{- $secretName := printf "%s-secret-old" (include "opensearch.fullname" .) }}
 {{- if not (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "opensearch.fullname" .))) | default dict }}
@@ -22,6 +22,5 @@ data: {{ get $secretObj "data" | toYaml | nindent 2 }}
 stringData:
   username: "{{ (include "opensearch.username" .) }}"
   password: "{{ (include "opensearch.password" .) }}"
-{{- end }}
 {{- end }}
 {{- end }}

--- a/controllers/opensearchservice_reconciler.go
+++ b/controllers/opensearchservice_reconciler.go
@@ -153,6 +153,9 @@ func (r *OpenSearchServiceReconciler) calculateSecretDataHash(secretName string,
 
 // parseOpenSearchCredentials gets credentials from OpenSearch secret
 func (r *OpenSearchServiceReconciler) parseOpenSearchCredentials(cr *opensearchservice.OpenSearchService, logger logr.Logger) util.Credentials {
+	if cr.Spec.ExternalOpenSearch != nil {
+		return r.parseSecretCredentials(fmt.Sprintf(secretPattern, cr.Name), cr.Namespace, logger)
+	}
 	return r.parseSecretCredentials(fmt.Sprintf(oldSecretPattern, cr.Name), cr.Namespace, logger)
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Deploying opensearch-service-operator with external OpenSearch support enabled results in an error when monitoring changes to secrets. Furthermore, many clients of the operator used opensearch-secret-old credentials by default. Changed that logic to use opensearch-secret in case of enabling external OpenSearch. 

## Related Tickets & Documents


- Related Issue - CPDEV-110661
- Closes #

## QA Instructions, Screenshots, Recordings



### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
