### PR TITLE
Fix error for users who has failed opendistro_security_roles and empty mapping roles

### DIFF
--- a/charts/helm/opensearch-service/templates/opensearch/security-auto-config.yaml
+++ b/charts/helm/opensearch-service/templates/opensearch/security-auto-config.yaml
@@ -115,7 +115,8 @@ stringData:
       backend_roles:
         - opensearch_security_anonymous_backendrole
     all_access:
-      - "{{ (include "opensearch.username" .) }}"
+      backend_roles:
+        - admin
       reserved: false
       description: "Maps admin to all_access"
   tenants.yml: |-

--- a/charts/helm/opensearch-service/templates/opensearch/security-auto-config.yaml
+++ b/charts/helm/opensearch-service/templates/opensearch/security-auto-config.yaml
@@ -115,6 +115,7 @@ stringData:
       backend_roles:
         - opensearch_security_anonymous_backendrole
     all_access:
+      - "{{ (include "opensearch.username" .) }}"
       reserved: false
       description: "Maps admin to all_access"
   tenants.yml: |-

--- a/controllers/opensearch_reconciler.go
+++ b/controllers/opensearch_reconciler.go
@@ -593,7 +593,6 @@ func (r OpenSearchReconciler) processSecurity() (*util.RestClient, error) {
 	if err != nil {
 		return restClient, err
 	}
-	log.Info(fmt.Sprint(allaccessRole.BackendRoles))
 	if allaccessRole.BackendRoles == nil {
 		credentials := r.reconciler.parseSecretCredentials(fmt.Sprintf(secretPattern, r.cr.Name), r.cr.Namespace, r.logger)
 		err = r.UpdateRoles(restClient, credentials.Username, "all_access")

--- a/controllers/opensearch_reconciler.go
+++ b/controllers/opensearch_reconciler.go
@@ -847,18 +847,18 @@ func (r OpenSearchReconciler) getRoleMappingListFromSecret(secretName string) ([
 	return mappings, nil
 }
 
-func (r OpenSearchReconciler) getRoleMapping(restClient *util.RestClient, roleName string) (*OpenSearchRoleMapping, error) {
+func (r OpenSearchReconciler) getRoleMapping(restClient *util.RestClient, roleName string) (OpenSearchRoleMapping, error) {
 	requestPath := fmt.Sprintf("_plugins/_security/api/rolesmapping/%s", roleName)
 	_, responseBody, err := restClient.SendRequest(http.MethodGet, requestPath, nil)
 	if err != nil {
 		log.Error(err, "An error occurred during audit config request")
-		return nil, err
+		return OpenSearchRoleMapping{}, err
 	}
 	var mappings OpenSearchRoleMapping
 	if err = json.Unmarshal(responseBody, &mappings); err != nil {
-		return nil, err
+		return OpenSearchRoleMapping{}, err
 	}
-	return &mappings, nil
+	return mappings, nil
 }
 
 func (r OpenSearchReconciler) UpdateRoles(restClient *util.RestClient, userName string, role string) error {

--- a/controllers/opensearch_reconciler.go
+++ b/controllers/opensearch_reconciler.go
@@ -579,7 +579,6 @@ func (r OpenSearchReconciler) Configure() error {
 }
 
 func (r OpenSearchReconciler) processSecurity() (*util.RestClient, error) {
-	log.Info("AAAAAAAAAAAAAAAAAAAAAAAAA")
 	restClient, err := r.updateCredentials()
 	if err != nil {
 		if strings.Contains(err.Error(), "is read-only") {

--- a/controllers/opensearch_reconciler.go
+++ b/controllers/opensearch_reconciler.go
@@ -594,12 +594,12 @@ func (r OpenSearchReconciler) processSecurity() (*util.RestClient, error) {
 		}
 		return restClient, err
 	}
-	credentials := r.reconciler.parseSecretCredentials(fmt.Sprintf(secretPattern, r.cr.Name), r.cr.Namespace, r.logger)
 	allaccessRole, err := r.getRoleMapping(restClient, "all_access")
 	if err != nil {
 		return restClient, err
 	}
 	if allaccessRole.BackendRoles == nil {
+		credentials := r.reconciler.parseSecretCredentials(fmt.Sprintf(secretPattern, r.cr.Name), r.cr.Namespace, r.logger)
 		r.UpdateRoles(restClient, credentials.Username, "all_access")
 	}
 	if r.cr.Spec.OpenSearch.DisabledRestCategories != nil {

--- a/controllers/opensearch_reconciler.go
+++ b/controllers/opensearch_reconciler.go
@@ -864,8 +864,7 @@ func (r OpenSearchReconciler) getRoleMapping(restClient *util.RestClient, roleNa
 func (r OpenSearchReconciler) UpdateRoles(restClient *util.RestClient, userName string, role string) error {
 	log.Info(fmt.Sprintf("start Update mapping roles for user:%s ", userName))
 	requestPath := "_plugins/_security/api/rolesmapping"
-	value := fmt.Sprintf(`{"backend_roles": ["%s"]}`, userName)
-	body := fmt.Sprintf(`[{"op": "add", "path": "/%s", "value": %s}]`, role, value)
+	body := fmt.Sprintf(`[{"op": "add", "path": "/%s", "value": {"backend_roles": ["admin"]}}]`, role)
 	statusCode, responseBody, err := restClient.SendRequest(http.MethodPatch, requestPath, strings.NewReader(body))
 	if err == nil {
 		if statusCode == http.StatusOK {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed a bug, after deploying opensearch, we change the password, an error appears. Now the user is added to the mapping roles field and the opendistro_security_roles field is cleared

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #
- Docker OpenSearch PR: https://github.com/Netcracker/qubership-docker-opensearch/pull/8

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
