### PR TITLE
Fix: add velero.io/timeout property

### DIFF
--- a/charts/helm/opensearch-service/templates/operator/deployment.yaml
+++ b/charts/helm/opensearch-service/templates/operator/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       {{- if and (not .Values.global.externalOpensearch.enabled) .Values.global.velero.preHookBackupEnabled }}
       annotations:
         pre.hook.backup.velero.io/command: {{ template "opensearch.velero-pre-hook-backup-flush" . }}
+        pre.hook.backup.velero.io/timeout: {{ .Values.global.velero.timeout | default "600s" }}
       {{- end }}
     spec:
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/helm/opensearch-service/values.yaml
+++ b/charts/helm/opensearch-service/values.yaml
@@ -155,6 +155,7 @@ global:
 
   velero:
     preHookBackupEnabled: true
+    timeout: "600s"
 
   psp:
     create: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[Nuuday] [STG03] Velero backup fail with error : executing hook from opensearch service-operator namespace.
Velero backup failing on multiple iterations with similar error: Error Validating webhook. for one pod opensearch-service-operator from opensearch namespace. 

## Related Tickets & Documents
- Related Issue #PSUPCLCAP-231
- Closes #PSUPCLCAP-231

## QA Instructions, Screenshots, Recordings

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
