### PR TITLE
Add missing permissions for Restricted deployment failure

### DIFF
--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -279,6 +279,18 @@ To avoid using `cluster-wide` rights during the deployment, the following condit
           - create
           - get
           - patch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+        verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
     ```
 
     </details>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

After configuring restricted user rights on environment, error reported:
Error from server (Forbidden): daemonsets.apps is forbidden: User "system:serviceaccount:kube-system:restricted-sa" cannot list resource "daemonsets" in API group "apps" in the namespace "opensearch"

During deploy using restricted service account, role and role binding must be created for this service account. Some permissions are missed in the role that we provide in documentation.
Added missing permissions.

## Related Tickets & Documents

- Related Issue #CPCAP-2833
- Closes #CPCAP-2833

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
