### PR TITLE
feat: add vulnerability scan workflow using Trivy and Grype

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,52 @@
+name: Vulnerability Scan
+run-name: Vulnerability Scan for ${{ inputs.target }} ${{ inputs.image && format('({0})', inputs.image) || '' }}
+# This workflow performs security vulnerability scanning on Docker images or source code
+# using Trivy and Grype tools. It can be triggered manually via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Scan part"
+        required: true
+        default: "docker"
+        type: choice
+        options:
+          - docker
+          - source
+      image:
+        description: "Docker image (for docker). By default ghcr.io/<owner>/<repo>:latest"
+        required: false
+        default: ""
+        type: string
+      only-high-critical:
+        description: "Scope only HIGH + CRITICAL"
+        required: false
+        default: true
+        type: boolean
+      trivy-scan:
+        description: "Trivy scan"
+        required: false
+        default: true
+        type: boolean
+      grype-scan:
+        description: "Grype scan"
+        required: false
+        default: true
+        type: boolean
+      continue-on-error:
+        description: "Continue on error"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  security-scan:
+    uses: Netcracker/qubership-workflow-hub/.github/workflows/re-security-scan.yml@main
+    with:
+      target: ${{ inputs.target }}
+      image: ${{ inputs.image }}
+      only-high-critical: ${{ inputs.only-high-critical }}
+      trivy-scan: ${{ inputs.trivy-scan }}
+      grype-scan: ${{ inputs.grype-scan }}
+      continue-on-error: ${{ inputs.continue-on-error }}


### PR DESCRIPTION
Overview
This PR adds a new GitHub Actions workflow for automated security vulnerability scanning of Docker images and source code using industry-standard tools (Trivy and Grype). The workflow provides flexible configuration options and integrates with the organization's centralized workflow hub for consistent security practices across repositories.

What's Changed
Added .github/workflows/security-scan.yml - a new GitHub Actions workflow that enables on-demand security scanning with the following capabilities:

Key Features
🔘 Manual Trigger

Workflow can be triggered on-demand via workflow_dispatch from the GitHub Actions UI
No automatic triggers to avoid unnecessary CI/CD overhead
🎯 Flexible Target Selection

Docker Mode: Scan Docker images for vulnerabilities in dependencies and base images
Source Mode: Scan source code for security issues and vulnerable dependencies
Configurable Docker image path (defaults to ghcr.io/<owner>/<repo>:latest)
⚡ Severity Filtering

Optional filtering to show only HIGH and CRITICAL severity vulnerabilities
Enabled by default to focus on actionable security issues
Can be disabled to see all vulnerability levels
🛡️ Dual Scanning Tools

Trivy: Industry-standard vulnerability scanner with comprehensive CVE database
Grype: Additional scanner for cross-validation and broader coverage
Both tools enabled by default with individual toggle controls
Provides redundancy and reduces false negatives
⚙️ Error Handling

Configurable continue-on-error behavior
Enabled by default to prevent workflow failures from blocking other processes
Can be disabled for stricter enforcement in specific scenarios
🔄 Centralized Integration

Leverages reusable workflow from Netcracker/qubership-workflow-hub
Ensures consistent security scanning practices across all Qubership repositories
Reduces maintenance overhead through centralized updates
Workflow Inputs
Input	Type	Default	Description
target	choice	docker	Scan target: Docker image or source code
image	string	""	Docker image path (optional, uses default if empty)
only-high-critical	boolean	true	Filter to show only HIGH and CRITICAL vulnerabilities
trivy-scan	boolean	true	Enable Trivy vulnerability scanner
grype-scan	boolean	true	Enable Grype vulnerability scanner
continue-on-error	boolean	true	Continue workflow execution on scanner errors
Usage Example
To run a security scan:

Navigate to the Actions tab in the GitHub repository
Select "Vulnerability Scan" from the workflow list
Click "Run workflow"
Configure the scan parameters:
Choose docker to scan a Docker image or source to scan the codebase
Optionally specify a Docker image (e.g., ghcr.io/netcracker/qubership-opensearch:latest)
Toggle scanning options as needed
Review the vulnerability report in the workflow run output
Quality Assurance
✅ YAML syntax validated successfully
✅ Follows existing repository workflow patterns
✅ Integrates with centralized qubership-workflow-hub
✅ No breaking changes to existing workflows
✅ Well-documented with inline comments and clear input descriptions
Alignment with Evergreen Strategy
This workflow directly supports the repository's Evergreen strategy by:

Vulnerabilities fixing: Automated detection of security vulnerabilities in dependencies and code
Proactive security: Regular scanning helps identify issues before they become critical
Continuous improvement: Integration with centralized workflow hub ensures updates to scanning tools and practices
Notes
The reusable workflow Netcracker/qubership-workflow-hub/.github/workflows/re-security-scan.yml@main must be accessible for this workflow to function
Repository must have appropriate permissions for security scanning tools
Consider scheduling this workflow or adding it to PR/push triggers for continuous security monitoring
Testing
The workflow has been validated for:

✅ YAML syntax correctness
✅ Consistency with repository workflow patterns
✅ Integration with qubership-workflow-hub
Manual testing can be performed by running the workflow through the GitHub Actions UI as described in the usage example above.