### PR TITLE
feat: Add workflow for cleaning up old Docker container versions

### DIFF
--- a/.github/workflows/cleanup_containers.yml
+++ b/.github/workflows/cleanup_containers.yml
@@ -1,0 +1,71 @@
+---
+# This workflow is designed to clean up old Docker container versions in a GitHub repository.
+name: Cleanup Old Docker Container Versions
+run-name: "${{ github.event_name }} - ${{ github.actor }}"
+on:
+  schedule:
+   - cron: "0 0 * * 0" # Runs weekly on Sunday at midnight
+  workflow_dispatch:
+    inputs:
+      threshold-days:
+        description: "Number of days to keep container versions"
+        required: false
+        default: "7"
+      included-tags:
+        description: "Tags to include for deletion"
+        required: false
+        default: "dev*"
+      excluded-tags:
+        description: "Tags to exclude from deletion"
+        required: false
+        default: "release*,semver"
+      dry-run:
+        description: "Enable dry-run mode"
+        required: false
+        default: true
+        type: boolean
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: "Cleanup Old Docker Container Versions"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Setup Environment"
+        run: |
+            echo "Setting up environment for cleanup..."
+            if [ '${{ github.event_name}}' == 'schedule' ]; then
+              echo "Scheduled run detected."
+              echo "INCLUDED_TAGS=*" >> $GITHUB_ENV
+              echo "EXCLUDED_TAGS=release*,semver" >> $GITHUB_ENV
+            else
+              echo "Manual run triggered by ${{ github.actor }}."
+              echo "INCLUDED_TAGS=${{ github.event.inputs.included-tags }}" >> $GITHUB_ENV
+              echo "EXCLUDED_TAGS=${{ github.event.inputs.excluded-tags }}" >> $GITHUB_ENV
+            fi
+      - name: "Summary"
+        run: |
+          echo "**Event**: ${{ github.event_name }}"
+          echo "**Actor**: ${{ github.actor }}"
+          echo "**Threshold days**: ${{ github.event.inputs.threshold-days || 7 }}"
+          echo "**Included tags**: ${INCLUDED_TAGS}"
+          echo "**Excluded tags**: ${EXCLUDED_TAGS}"
+          echo "**Dry-run**: ${{ github.event.inputs.dry-run || 'false' }}"
+
+      - name: "Login to GHCR"
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_RWD_PACKAGE_TOKEN }}
+
+      - name: "Run Container Package Cleanup Action"
+        uses: netcracker/qubership-workflow-hub/actions/container-package-cleanup@v2.0.0
+        with:
+          threshold-days: ${{ github.event.inputs.threshold-days || 7 }}
+          included-tags: ${{ env.INCLUDED_TAGS }}
+          excluded-tags: ${{ env.EXCLUDED_TAGS }}
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+        env:
+          PACKAGE_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Introduce a GitHub Actions workflow that automates the cleanup of old Docker container versions based on specified criteria, including retention days and tag filters. The workflow can be triggered manually or scheduled weekly.
Related issue: Netcracker/qubership-workflow-hub#457