### PR TITLE
fix: Repair night ci for OpenSearch

### DIFF
--- a/.github/workflows/cleanup-old-docker-container.yaml
+++ b/.github/workflows/cleanup-old-docker-container.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "**Debug**: $DEBUG"
 
       - name: "Run Container Package Cleanup Action"
-        uses: netcracker/qubership-workflow-hub/actions/container-package-cleanup@test2 #v2.0.5
+        uses: netcracker/qubership-workflow-hub/actions/container-package-cleanup@502dcf4513f33195d8c5bae39207117f390310ca #v2.0.5
         with:
           threshold-days: ${{ env.THRESHOLD_DAYS }}
           included-tags: ${{ env.INCLUDED_TAGS }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Repair night ci for OpenSearch

Error in pipeline:
``
 error[unpinned-uses]: unpinned action reference
    --> /github/workspace/.github/workflows/cleanup-old-docker-container.yaml:59:9
     |
  59 |         uses: netcracker/qubership-workflow-hub/actions/container-package-cleanup@test #v2.0.5
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
     |
     = note: audit confidence → High
``

add tag that is a pointer to a specific SHA - in this case:
https://github.com/Netcracker/qubership-workflow-hub/commit/502dcf4513f33195d8c5bae39207117f390310ca

https://github.com/Netcracker/qubership-opensearch/actions/runs/20457511529

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
