### PR TITLE
Use TLS port 8443 for adapter server

### DIFF
--- a/dbaas-adapter/server/server.go
+++ b/dbaas-adapter/server/server.go
@@ -76,12 +76,16 @@ func Server(ctx context.Context, adapterAddress string, adapterUsername string, 
 		return
 	}
 
-	server := &http.Server{
-		Addr:    ":8080",
-		Handler: hnd,
+	isTlsEnabled := strings.Contains(adapterAddress, common.Https)
+	port := ":8080"
+	if isTlsEnabled {
+		port = ":8443"
 	}
 
-	isTlsEnabled := strings.Contains(adapterAddress, common.Https)
+	server := &http.Server{
+		Addr:    port,
+		Handler: hnd,
+	}
 	logger := common.GetLogger()
 
 	go func() {


### PR DESCRIPTION
### Motivation
- Ensure the HTTP server uses the conventional TLS port when TLS is enabled so the listening port matches the secure protocol.
- Avoid confusion where the server uses `:8080` even when serving TLS via `ListenAndServeTLS`.

### Description
- Detect TLS usage from `adapterAddress` (`strings.Contains(adapterAddress, common.Https)`) earlier in `Server`.
- Select the listen address into a `port` variable set to `":8080"` by default and `":8443"` when TLS is enabled.
- Set `server.Addr` to the chosen `port` so `ListenAndServeTLS` runs on `:8443` when appropriate.
- No other server behavior or handler wiring was changed.

### Testing
- No automated tests were executed as part of this change.
- Change was limited to port selection logic and does not modify request handlers or TLS certificate paths.
- Manual runtime verification is recommended to ensure the server binds correctly in containerized deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696500877e748330bc30e41301c27e33)