### PR TITLE
fix: Implement retry operation for bulk drop request

### DIFF
--- a/dbaas-adapter/basic/basic.go
+++ b/dbaas-adapter/basic/basic.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Netcracker/dbaas-opensearch-adapter/cluster"
 	"github.com/Netcracker/dbaas-opensearch-adapter/common"
@@ -31,6 +32,7 @@ import (
 	core "github.com/Netcracker/qubership-dbaas-adapter-core/pkg/utils"
 	"github.com/gorilla/mux"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -159,14 +161,22 @@ func (bp BaseProvider) BulkDropResourceHandler() func(w http.ResponseWriter, r *
 		}
 		defer func() { _ = r.Body.Close() }()
 
-		deletedResources := bp.deleteResources(resources, ctx)
-		failedResources := getResourcesWithFailedStatus(deletedResources)
 		var resourcesToReturn []dao.DbResource
-		if len(failedResources) > 0 {
-			resourcesToReturn = failedResources
+		err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 3*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			deletedResources := bp.deleteResources(resources, ctx)
+			successfulResources, failedResources := getResourcesWithSuccessfulAndFailedStatus(deletedResources)
+			resourcesToReturn = append(resourcesToReturn, successfulResources...)
+			if len(failedResources) > 0 {
+				logger.WarnContext(ctx, fmt.Sprintf("Some of the resources can't be deleted due to errors: %+v", failedResources))
+				resources = failedResources
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			resourcesToReturn = resources
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
-			resourcesToReturn = deletedResources
 			w.WriteHeader(http.StatusOK)
 		}
 		bytesResult, err := json.Marshal(resourcesToReturn)
@@ -769,7 +779,9 @@ func (bp BaseProvider) GetExtendedConnectionProperties(dbName string, username s
 func (bp BaseProvider) deleteResources(resources []dao.DbResource, ctx context.Context) []dao.DbResource {
 	var deletedResources []dao.DbResource
 
-	resources = append(resources, bp.processResourcePrefixKind(resources, ctx)...)
+	additionalResources, failedResources := bp.processResourcePrefixKind(resources, ctx)
+	resources = append(resources, additionalResources...)
+	deletedResources = append(deletedResources, failedResources...)
 
 	users := bp.deleteResourcesByKind(resources, common.UserKind)
 	deletedResources = append(deletedResources, users...)
@@ -792,8 +804,9 @@ func (bp BaseProvider) deleteResources(resources []dao.DbResource, ctx context.C
 	return deletedResources
 }
 
-func (bp BaseProvider) processResourcePrefixKind(resources []dao.DbResource, ctx context.Context) []dao.DbResource {
+func (bp BaseProvider) processResourcePrefixKind(resources []dao.DbResource, ctx context.Context) ([]dao.DbResource, []dao.DbResource) {
 	var additionalResources []dao.DbResource
+	var failedResources []dao.DbResource
 	for _, resource := range resources {
 		if resource.Kind == common.ResourcePrefixKind {
 			namePattern := fmt.Sprintf("%s*", resource.Name)
@@ -807,26 +820,27 @@ func (bp BaseProvider) processResourcePrefixKind(resources []dao.DbResource, ctx
 					{Kind: common.AliasKind, Name: namePattern},
 				}...)
 			} else if bp.ApiVersion == common.ApiV2 {
-				additionalResources = append(additionalResources, []dao.DbResource{
-					{Kind: common.IndexKind, Name: namePattern},
-					{Kind: common.MetadataKind, Name: resource.Name},
-					{Kind: common.TemplateKind, Name: namePattern},
-					{Kind: common.IndexTemplateKind, Name: namePattern},
-					{Kind: common.AliasKind, Name: namePattern},
-				}...)
 				users, err := bp.getUsersByPrefix(resource.Name)
 				if err != nil {
 					logger.ErrorContext(ctx, fmt.Sprintf("Failed to receive users with prefix %s ", resource.Name), slog.Any("error", err))
+					failedResources = append(additionalResources, *getResourceDeletionFailedStatus(resource, err))
 				} else {
 					for _, user := range users {
 						additionalResources = append(additionalResources,
 							dao.DbResource{Kind: common.UserKind, Name: user})
 					}
+					additionalResources = append(additionalResources, []dao.DbResource{
+						{Kind: common.IndexKind, Name: namePattern},
+						{Kind: common.MetadataKind, Name: resource.Name},
+						{Kind: common.TemplateKind, Name: namePattern},
+						{Kind: common.IndexTemplateKind, Name: namePattern},
+						{Kind: common.AliasKind, Name: namePattern},
+					}...)
 				}
 			}
 		}
 	}
-	return additionalResources
+	return additionalResources, failedResources
 }
 
 func (bp BaseProvider) deleteResourcesByKind(resources []dao.DbResource, kind string) []dao.DbResource {
@@ -955,14 +969,17 @@ func getResourceDeletionFailedStatus(resource dao.DbResource, err error) *dao.Db
 	}
 }
 
-func getResourcesWithFailedStatus(resources []dao.DbResource) []dao.DbResource {
-	var result []dao.DbResource
+func getResourcesWithSuccessfulAndFailedStatus(resources []dao.DbResource) ([]dao.DbResource, []dao.DbResource) {
+	var deletedResources []dao.DbResource
+	var failedResources []dao.DbResource
 	for _, resource := range resources {
 		if resource.Status == DeletionFailedStatus {
-			result = append(result, resource)
+			failedResources = append(failedResources, resource)
+		} else {
+			deletedResources = append(deletedResources, resource)
 		}
 	}
-	return result
+	return deletedResources, failedResources
 }
 
 func buildIndexName(dbName string, prefix string) string {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In this pull request two moments are being considered:
1) Lack of retry for `bulk-drop` operation for DBaaS adapter.
2) Undeleted users in `bulk-drop` operation if something went wrong at the time of their receipt.

What's done:
1. Added `wait.PollUntilContextTimeout` to delete resources, removing only failed ones on each subsequent iteration.
2. If we couldn't get users during resourcePrefix processing, we add resourcePrefix to failed resources and move on to the next iteration.

Testing:
1. Create database:
```
curl -u <username>:<password> -XPOST http://dbaas-opensearch-adapter:8080/api/v2/dbaas/adapter/opensearch/databases -d'
{
  "settings": {
    "resourcePrefix": true,
    "createOnly": [
      "user", "index"
    ]
  },
  "metadata": {
    "classifier": {
       "namespace": "test-namespace"
   },
    "microserviceName": "test-service"
  }
}'
```
Result:
```
{"name":"test-service_test-namespace_043607649160426_bccf4716-486a-4417-bd41-4e6c6896ae2c","connectionProperties":[{"dbName":"","host":"opensearch.opensearch-service-v2","port":9200,"url":"https://opensearch.opensearch-service-v2:9200/","username":"test-service_test-namespace_043607649160426_bcec499986594f768e2c0a53d8bf920f","password":"qIZVzU5H@A","resourcePrefix":"test-service_test-namespace_043607649160426","role":"readonly"},{"dbName":"","host":"opensearch.opensearch-service-v2","port":9200,"url":"https://opensearch.opensearch-service-v2:9200/","username":"test-service_test-namespace_043607649160426_2656f790dd22498faa25a7c12c027ae7","password":"8cSkojb_ON","resourcePrefix":"test-service_test-namespace_043607649160426","role":"dml"},{"dbName":"","host":"opensearch.opensearch-service-v2","port":9200,"url":"https://opensearch.opensearch-service-v2:9200/","username":"test-service_test-namespace_043607649160426_50fcb91dc98c4ac4aaaa7e33aa208c01","password":"9cAo_CYIzH","resourcePrefix":"test-service_test-namespace_043607649160426","role":"admin"},{"dbName":"","host":"opensearch.opensearch-service-v2","port":9200,"url":"https://opensearch.opensearch-service-v2:9200/","username":"test-service_test-namespace_043607649160426_7b18330b32ad4ea59a66c085979c7662","password":"FZ1nbaO$fP","resourcePrefix":"test-service_test-namespace_043607649160426","role":"ism"}],"resources":[{"kind":"resourcePrefix","name":"test-service_test-namespace_043607649160426"},{"kind":"user","name":"test-service_test-namespace_043607649160426_bcec499986594f768e2c0a53d8bf920f"},{"kind":"user","name":"test-service_test-namespace_043607649160426_2656f790dd22498faa25a7c12c027ae7"},{"kind":"user","name":"test-service_test-namespace_043607649160426_50fcb91dc98c4ac4aaaa7e33aa208c01"},{"kind":"user","name":"test-service_test-namespace_043607649160426_7b18330b32ad4ea59a66c085979c7662"},{"kind":"index","name":"test-service_test-namespace_043607649160426_bccf4716-486a-4417-bd41-4e6c6896ae2c"},{"kind":"metadataDocument","name":"test-service_test-namespace_043607649160426_bccf4716-486a-4417-bd41-4e6c6896ae2c"}]}
```
2. Get resource prefix from the result: `{"kind":"resourcePrefix","name":"test-service_test-namespace_043607649160426"}`
3. Restart OpenSearch pods (for the first issue I tried to restart several pods, but it's difficult to reproduce; for the second issue all OpenSearch pods were being restarted).
4. Run deletion operation:
```
curl -u <username>:<password> -XPOST http://dbaas-opensearch-adapter:8080/api/v2/dbaas/adapter/opensearch/resources/bulk-drop -d'[
  {
    "kind": "resourcePrefix",
    "name": "test-service_test-namespace_043607649160426"
  }
]'
```
5. For the second case we saw the following logs in OpenSearch DBaaS adapter:
```
[2026-04-15T16:43:36.24] [INFO] [request_id=4d07f3781679424aba00b4098fa7b53b] [tenant_id= ] [thread= ] [class= ] Request to delete OpenSearch resources is received
[2026-04-15T16:43:36.248] [ERROR] [request_id= ] [tenant_id= ] [thread= ] [class= ] Failed to receive users with prefix test-service_test-namespace_164148656150426 
[2026-04-15T16:43:36.248] [WARN] [request_id= ] [tenant_id= ] [thread= ] [class= ] Some of the resources can't be deleted due to errors: [{Kind:resourcePrefix Name:test-service_test-namespace_164148656150426 ErrorMessage:failed to receive users: dial tcp 172.30.190.193:9200: connect: connection refused Status:DELETE_FAILED}]
[2026-04-15T16:43:38.698] [ERROR] [request_id=5c5b48bf60494b82824e63b12058bfc8] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:43:42.892] [ERROR] [request_id=8481ad0e11be47d9b3721530db10cea5] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:43:48.819] [ERROR] [request_id=105b5411403b4436af87720215d91891] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:43:54.203] [ERROR] [request_id=b8e595503e414d9dbfa523b7c985f628] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:43:58.148] [ERROR] [request_id=1776271438014.0.022712544685931868] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:00.879] [ERROR] [request_id=2479cdca89314525a99e04a8777f75ee] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:06.328] [ERROR] [request_id= ] [tenant_id= ] [thread= ] [class= ] Failed to receive users with prefix test-service_test-namespace_164148656150426 
[2026-04-15T16:44:06.328] [WARN] [request_id= ] [tenant_id= ] [thread= ] [class= ] Some of the resources can't be deleted due to errors: [{Kind:resourcePrefix Name:test-service_test-namespace_164148656150426 ErrorMessage:during receiving users by prefix test-service_test-namespace_164148656150426 error occurred: &{_:[] body:0xc000364a80 zr:<nil> zerr:<nil>} Status:DELETE_FAILED}]
[2026-04-15T16:44:07.605] [ERROR] [request_id=7c3a896022f74a65bace98dc6b9ec18e] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:08.837] [ERROR] [request_id=44e1b7fe2cc04bbe9fdd4d75e1f23159] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:14.151] [ERROR] [request_id=1776271454016.0.9597843538586055] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:18.828] [ERROR] [request_id=9d5c506c4c154b4aa411f99a1cfe9b7c] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:23.404] [ERROR] [request_id=3e92b9c3a98f432e962c1b5d2b748c4a] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:28.824] [ERROR] [request_id=6d4c3ca7400d4bfaa7f77c1573e5f1c8] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:36.26] [ERROR] [request_id= ] [tenant_id= ] [thread= ] [class= ] Failed to receive users with prefix test-service_test-namespace_164148656150426 
[2026-04-15T16:44:36.26] [WARN] [request_id= ] [tenant_id= ] [thread= ] [class= ] Some of the resources can't be deleted due to errors: [{Kind:resourcePrefix Name:test-service_test-namespace_164148656150426 ErrorMessage:during receiving users by prefix test-service_test-namespace_164148656150426 error occurred: &{_:[] body:0xc000364c40 zr:<nil> zerr:<nil>} Status:DELETE_FAILED}]
[2026-04-15T16:44:37.708] [ERROR] [request_id=e8df45dcb713487796f19fe4e429edf5] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:38.84] [ERROR] [request_id=b810e9ab426e4beeb76f48346c061f4e] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:48.82] [ERROR] [request_id=602625983a3a48d9bea82a31b7a2117d] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:54.698] [ERROR] [request_id=03c19dc2d1d24906926f11e46d9a0914] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:44:58.829] [ERROR] [request_id=92fce191027640c88883bba5ae07bfe6] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:06.283] [ERROR] [request_id= ] [tenant_id= ] [thread= ] [class= ] Failed to receive users with prefix test-service_test-namespace_164148656150426 
[2026-04-15T16:45:06.283] [WARN] [request_id= ] [tenant_id= ] [thread= ] [class= ] Some of the resources can't be deleted due to errors: [{Kind:resourcePrefix Name:test-service_test-namespace_164148656150426 ErrorMessage:during receiving users by prefix test-service_test-namespace_164148656150426 error occurred: &{_:[] body:0xc000364140 zr:<nil> zerr:<nil>} Status:DELETE_FAILED}]
[2026-04-15T16:45:08.827] [ERROR] [request_id=b934a488eb2b4c1886ee6c95af60257a] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:10.908] [ERROR] [request_id=b0b58da83af14bd5a7fe3cb44a117ee1] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:15.836] [INFO] [request_id=991cdfea1bf241b090812ad35265a665] [tenant_id= ] [thread= ] [class= ] Received request to get physical database
10.130.16.85 - - [15/Apr/2026:16:45:15 +0000] "GET /api/v2/dbaas/adapter/opensearch/physical_database HTTP/1.1" 200 39
[2026-04-15T16:45:15.841] [INFO] [request_id=edc5bd073f334ebf957e25e5932e38aa] [tenant_id= ] [thread= ] [class= ] Checked success code for physical database registration
[2026-04-15T16:45:15.841] [INFO] [request_id=edc5bd073f334ebf957e25e5932e38aa] [tenant_id= ] [thread= ] [class= ] Successfully registered physical database, set health OK
[2026-04-15T16:45:18.823] [ERROR] [request_id=ab54588819064654af4a24428cef19fb] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:25.396] [ERROR] [request_id=998776254b31468e8053bab869e32cd4] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:28.816] [ERROR] [request_id=7a2d5fc5d8244be5a5600f1db5ae81c9] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:36.327] [ERROR] [request_id= ] [tenant_id= ] [thread= ] [class= ] Failed to receive users with prefix test-service_test-namespace_164148656150426 
[2026-04-15T16:45:36.327] [WARN] [request_id= ] [tenant_id= ] [thread= ] [class= ] Some of the resources can't be deleted due to errors: [{Kind:resourcePrefix Name:test-service_test-namespace_164148656150426 ErrorMessage:during receiving users by prefix test-service_test-namespace_164148656150426 error occurred: &{_:[] body:0xc00007c680 zr:<nil> zerr:<nil>} Status:DELETE_FAILED}]
[2026-04-15T16:45:38.829] [ERROR] [request_id=f67c48d87da24f9caca9d8e75055cb34] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:45:39.325] [ERROR] [request_id=03b8495877d54a418fe2f920cc31f00e] [tenant_id= ] [thread= ] [class= ] Failed to get cluster health
[2026-04-15T16:46:10.143] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] User with name [test-service_test-namespace_164148656150426_0225175290c54995bc75b8d1a03b2186] is removed: &{_:[] body:0xc0003640c0 zr:<nil> zerr:<nil>}
[2026-04-15T16:46:10.711] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] User with name [test-service_test-namespace_164148656150426_96bfecf09dd147618defd0c51800c18d] is removed: &{_:[] body:0xc000364200 zr:<nil> zerr:<nil>}
[2026-04-15T16:46:11.662] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] User with name [test-service_test-namespace_164148656150426_2378a910ebe64a4cbd6b2232b999e446] is removed: &{_:[] body:0xc00007c580 zr:<nil> zerr:<nil>}
[2026-04-15T16:46:13.555] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] User with name [test-service_test-namespace_164148656150426_c5dd563dbb3744c0b731e0806877bdcc] is removed: &{_:[] body:0xc000364500 zr:<nil> zerr:<nil>}
[2026-04-15T16:46:15.654] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] Get metadata for 'test-service_test-namespace_164148656150426' index
[2026-04-15T16:46:16.064] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] Metadata is not found for 'test-service_test-namespace_164148656150426' index
[2026-04-15T16:46:16.064] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] Metadata for 'test-service_test-namespace_164148656150426' index does not exist, skip deletion
[2026-04-15T16:46:16.168] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] 'test-service_test-namespace_164148656150426*' template does not exist, skip deletion
[2026-04-15T16:46:16.261] [INFO] [request_id= ] [tenant_id= ] [thread= ] [class= ] 'test-service_test-namespace_164148656150426*' index template does not exist, skip deletion
10.129.232.84 - - [15/Apr/2026:16:43:36 +0000] "POST /api/v2/dbaas/adapter/opensearch/resources/bulk-drop HTTP/1.1" 200 956
```