### PR TITLE
fix: ProgressDeadlineExceeded error in deployment conditions while running tests

### DIFF
--- a/operator/charts/helm/opensearch-service/templates/integration-tests/deployment.yaml
+++ b/operator/charts/helm/opensearch-service/templates/integration-tests/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   strategy:
     type: RollingUpdate
   replicas: {{ template "opensearch.replicasForSingleService" . }}
+  progressDeadlineSeconds: {{ .Values.statusProvisioner.integrationTestsTimeout | default 300 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Kubernetes marks the deployment as unhealthy after 10 minutes due to failing health checks. ArgoCD detects this status and terminates the job.

As a solution, we need to set necessary value to the `progressDeadlineSeconds` field because by default it's 600 seconds.

What's done:
1. Added the `progressDeadlineSeconds` field to the integration tests deployment configuration, containing the actual timeout for tests to run.