### PR TITLE
fix: Skip non-StatefulSet PVC

### DIFF
--- a/operator/controllers/opensearch_reconciler.go
+++ b/operator/controllers/opensearch_reconciler.go
@@ -1101,12 +1101,7 @@ func (r OpenSearchReconciler) reconcileOpenSearchPVCSize(ctx context.Context, de
 
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
-		if !strings.HasPrefix(pvc.Name, prefix) {
-			continue
-		}
-		if strings.HasSuffix(pvc.Name, "-snapshots") {
-			r.logger.Info("Skipping non-StatefulSet PVC",
-				"pvc", pvc.Name)
+		if !strings.HasPrefix(pvc.Name, prefix) || strings.HasSuffix(pvc.Name, "-snapshots") {
 			continue
 		}
 		pvcs = append(pvcs, pvc)

--- a/operator/controllers/opensearch_reconciler.go
+++ b/operator/controllers/opensearch_reconciler.go
@@ -1104,6 +1104,11 @@ func (r OpenSearchReconciler) reconcileOpenSearchPVCSize(ctx context.Context, de
 		if !strings.HasPrefix(pvc.Name, prefix) {
 			continue
 		}
+		if strings.HasSuffix(pvc.Name, "-snapshots") {
+			r.logger.Info("Skipping non-StatefulSet PVC",
+				"pvc", pvc.Name)
+			continue
+		}
 		pvcs = append(pvcs, pvc)
 		cur := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 		if desired.Cmp(cur) < 0 {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In OpenSearch, there are the following two parameters:
opensearch.snapshots.size and opensearch.master.persistence.size

By design, reducing the size of an existing PVC (or the underlying Persistent Volume) is not supported by Kubernetes and by most storage providers.

**ER**: validation is to happen  master.persistence.size
**AR**: "Reconciliation cycle is failed: PVC shrinking is forbidden" when snapshots.size specified is more than master.persistence.size

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #CPCAP-10519
- Closes #

## QA Instructions, Screenshots, Recordings

_Set storage size for master.persistence less than snapshots.size
Clean deploy
Redeploy with same parameters._
<img width="739" height="107" alt="image" src="https://github.com/user-attachments/assets/6d31fb00-9f50-41b2-8017-1d29fe326d73" />

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
