### PR TITLE
fix: Skip non-StatefulSet PVC

### DIFF
--- a/operator/controllers/opensearch_reconciler.go
+++ b/operator/controllers/opensearch_reconciler.go
@@ -1101,7 +1101,7 @@ func (r OpenSearchReconciler) reconcileOpenSearchPVCSize(ctx context.Context, de
 
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
-		if !strings.HasPrefix(pvc.Name, prefix) {
+		if !strings.HasPrefix(pvc.Name, prefix) || strings.HasSuffix(pvc.Name, "-snapshots") {
 			continue
 		}
 		pvcs = append(pvcs, pvc)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In OpenSearch, there are the following two parameters:
opensearch.snapshots.size and opensearch.master.persistence.size

By design, reducing the size of an existing PVC (or the underlying Persistent Volume) is not supported by Kubernetes and by most storage providers.

ER: validation is to happen master.persistence.size
AR: "Reconciliation cycle is failed: PVC shrinking is forbidden" when snapshots.size specified is more than master.persistence.size

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
