### PR TITLE
fix: enable HTTPRoute by default in values.yaml and update Gateway re…

### DIFF
--- a/operator/charts/helm/opensearch-service/templates/_helpers.tpl
+++ b/operator/charts/helm/opensearch-service/templates/_helpers.tpl
@@ -1493,12 +1493,16 @@ Restricted environment.
 {{- $refs := index . 1 | default list -}}
 {{- $port := index . 2 -}}
 {{- if and $root.Values.GATEWAY_SYSTEM_NAME $root.Values.GATEWAY_SYSTEM_NAMESPACE }}
-- name: {{ $root.Values.GATEWAY_SYSTEM_NAME }}
+- group: gateway.networking.k8s.io
+  kind: Gateway
+  name: {{ $root.Values.GATEWAY_SYSTEM_NAME }}
   namespace: {{ $root.Values.GATEWAY_SYSTEM_NAMESPACE }}
   port: {{ $port }}
 {{- else if gt (len $refs) 0 }}
 {{- range $refs }}
-- name: {{ .name }}
+- group: gateway.networking.k8s.io
+  kind: Gateway
+  name: {{ .name }}
   namespace: {{ .namespace }}
   port: {{ $port }}
 {{- end }}

--- a/operator/charts/helm/opensearch-service/templates/dashboards/httproute.yaml
+++ b/operator/charts/helm/opensearch-service/templates/dashboards/httproute.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- include "opensearch-service.defaultLabels" . | nindent 4 }}
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.dashboards.envoyGateway.parentRefs 443) | nindent 2 }}
-  
+  {{- include "gateway.parentRefs" (list . .Values.dashboards.envoyGateway.parentRefs 443) | nindent 4 }}
+
   hostnames:
   {{- if .Values.dashboards.envoyGateway.host }}
     - {{ .Values.dashboards.envoyGateway.host | quote }}
@@ -29,7 +29,10 @@ spec:
             value: /
       backendRefs:
         - name: {{ $serviceName }}
+          group: ""
+          kind: Service
           port: {{ .Values.dashboards.service.port }}
+          weight: 1
 
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -41,7 +44,7 @@ metadata:
     {{- include "opensearch-service.defaultLabels" . | nindent 4 }}
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 80) | nindent 2 }}
+  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 80) | nindent 4 }}
 
   hostnames:
   {{- if .Values.dashboards.envoyGateway.host }}

--- a/operator/charts/helm/opensearch-service/templates/opensearch/Client-httproute.yaml
+++ b/operator/charts/helm/opensearch-service/templates/opensearch/Client-httproute.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "opensearch-service.defaultLabels" . | nindent 4 }}
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 443) | nindent 2 }}
+  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 443) | nindent 4 }}
 
   hostnames:
   {{- if .Values.opensearch.client.envoyGateway.host }}
@@ -30,7 +30,10 @@ spec:
             value: /
       backendRefs:
         - name: {{ $fullName }}-internal
+          group: ""
+          kind: Service
           port: 9200
+          weight: 1
 
 {{- if (eq (include "opensearch.tlsEnabled" .) "true") }}
 ---
@@ -70,7 +73,7 @@ metadata:
     {{- include "opensearch-service.defaultLabels" . | nindent 4 }}
 spec:
   parentRefs:
-  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 80) | nindent 2 }}
+  {{- include "gateway.parentRefs" (list . .Values.opensearch.client.envoyGateway.parentRefs 80) | nindent 4 }}
 
   hostnames:
   {{- if .Values.opensearch.client.envoyGateway.host }}

--- a/operator/charts/helm/opensearch-service/values.yaml
+++ b/operator/charts/helm/opensearch-service/values.yaml
@@ -60,10 +60,12 @@ dashboards:
 #        hosts:
 #          - chart-example.local
   envoyGateway:
-    enabled: false
+    enabled: true
     host: ""
     parentRefs:
-      - name: default-external-gateway
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: default-external-gateway
         namespace: gateway-system
   service:
     type: ClusterIP
@@ -649,10 +651,12 @@ opensearch:
       #    hosts:
       #      - chart-example.local
     envoyGateway:
-      enabled: false
+      enabled: true
       host: ""
       parentRefs:
-        - name: default-external-gateway
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: default-external-gateway
           namespace: gateway-system
     resources:
       limits:


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request updates the OpenSearch Service Helm chart to improve compatibility with Kubernetes Gateway API standards and enable Envoy Gateway by default. The main changes are focused on explicitly specifying resource types in references, updating values to use structured parent references, and correcting indentation for consistency in Helm templates.

**Gateway API compatibility and configuration improvements:**

* Updated all Gateway `parentRefs` in the Helm templates (`httproute.yaml`, `Client-httproute.yaml`, and `_helpers.tpl`) to explicitly specify `group`, `kind`, and `name`, aligning with Gateway API conventions. [[1]](diffhunk://#diff-df1d80adb598ca598f8150bdaaa3952fab5563c9b933e1281ce8ec2835701c52L1496-R1505) [[2]](diffhunk://#diff-083419325a982cc802dd1a6fd452e3d934aecad1b5f98e16ac486c0d19733f47L63-R68) [[3]](diffhunk://#diff-083419325a982cc802dd1a6fd452e3d934aecad1b5f98e16ac486c0d19733f47L652-R659)
* Modified the `values.yaml` files for both dashboards and opensearch to enable Envoy Gateway by default and to use structured parent references with `group`, `kind`, `name`, and `namespace` fields. [[1]](diffhunk://#diff-083419325a982cc802dd1a6fd452e3d934aecad1b5f98e16ac486c0d19733f47L63-R68) [[2]](diffhunk://#diff-083419325a982cc802dd1a6fd452e3d934aecad1b5f98e16ac486c0d19733f47L652-R659)

**Helm template consistency and correctness:**

* Fixed indentation for the `parentRefs` block in the HTTPRoute templates to ensure correct YAML structure and Helm rendering. [[1]](diffhunk://#diff-3b391d1816a88e45a0e7a84b0f55dd119513801fb1571380376fd3e01f0aa42aL14-R14) [[2]](diffhunk://#diff-3b391d1816a88e45a0e7a84b0f55dd119513801fb1571380376fd3e01f0aa42aL44-R47) [[3]](diffhunk://#diff-904072712cc1258a9c74543764d79a87454050487782a876a8b8197d5f79bcd6L15-R15) [[4]](diffhunk://#diff-904072712cc1258a9c74543764d79a87454050487782a876a8b8197d5f79bcd6L73-R76)
* In backend references for HTTPRoute, explicitly set `group: ""`, `kind: Service`, and `weight: 1` for clarity and correctness in service targeting. [[1]](diffhunk://#diff-3b391d1816a88e45a0e7a84b0f55dd119513801fb1571380376fd3e01f0aa42aR32-R35) [[2]](diffhunk://#diff-904072712cc1258a9c74543764d79a87454050487782a876a8b8197d5f79bcd6R33-R36)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue: CPCAP-10403
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
