### PR TITLE
fix: Actualize Curator probes

### DIFF
--- a/operator/charts/helm/opensearch-service/templates/_helpers.tpl
+++ b/operator/charts/helm/opensearch-service/templates/_helpers.tpl
@@ -1147,7 +1147,7 @@ Configure OpenSearch statefulset names for rolling update mechanism in operator.
 */}}
 {{- define "opensearch.statefulsetNames" -}}
     {{- $lst := list }}
-    {{ if and .Values.opensearch.data.enabled .Values.opensearch.data.dedicatedPod.enabled }}
+    {{- if and .Values.opensearch.data.enabled .Values.opensearch.data.dedicatedPod.enabled }}
         {{- $lst = append $lst (printf "%s-data" (include "opensearch.fullname" . )) }}
     {{- end }}
     {{- if .Values.opensearch.master.enabled }}

--- a/operator/charts/helm/opensearch-service/templates/curator/curator-deployment.yaml
+++ b/operator/charts/helm/opensearch-service/templates/curator/curator-deployment.yaml
@@ -176,8 +176,10 @@ spec:
           image: {{ template "curator.image" . }}
           imagePullPolicy: {{ .Values.curator.imagePullPolicy | default "Always" | quote }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health/live
               port: {{ template "curator.port" . }}
+              scheme: {{ eq (include "curator.tlsEnabled" .) "true" | ternary "HTTPS" "HTTP" }}
             failureThreshold: 5
             initialDelaySeconds: 30
             periodSeconds: 5
@@ -185,11 +187,11 @@ spec:
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: {{ template "curator.port" . }}
               scheme: {{ eq (include "curator.tlsEnabled" .) "true" | ternary "HTTPS" "HTTP" }}
             failureThreshold: 5
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
@@ -272,15 +274,18 @@ spec:
                 - /bin/sh
                 - '-c'
                 - ps aux | grep "python3 indices_cleaner.py"
-            initialDelaySeconds: 30
+            initialDelaySeconds: 20
             timeoutSeconds: 5
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 5
           readinessProbe:
-            tcpSocket:
-              port:  {{ template "curator.port" . }}
-            initialDelaySeconds: 60
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - ps aux | grep "python3 indices_cleaner.py"
+            initialDelaySeconds: 20
             timeoutSeconds: 5
             periodSeconds: 10
             successThreshold: 1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There are a lot of TLS handshake errors in OpenSearch curator logs when it's deployed with TLS:
```
[GIN] 2026/06/11 - 05:21:04 | 200 |  2.577999596s |    192.168.0.22 | GET      "/health"
[GIN] 2026/06/11 - 05:21:09 | 200 |  2.732858918s |    192.168.0.22 | GET      "/health"
[GIN] 2026/06/11 - 05:21:14 | 200 |  2.781901482s |    192.168.0.22 | GET      "/health"
[GIN] 2026/06/11 - 05:21:20 | 200 |  3.481696429s |    192.168.0.22 | GET      "/health"
2026/06/11 05:21:21 http: TLS handshake error from 192.168.0.22:56094: EOF
[GIN] 2026/06/11 - 05:21:26 | 200 |  4.823685265s |    192.168.0.22 | GET      "/health"
2026/06/11 05:21:26 http: TLS handshake error from 192.168.0.22:38702: EOF
[GIN] 2026/06/11 - 05:21:30 | 200 |  3.582795851s |    192.168.0.22 | GET      "/health"
2026/06/11 05:21:31 http: TLS handshake error from 192.168.0.22:38720: EOF
[GIN] 2026/06/11 - 05:21:33 | 200 |  2.019996927s |    192.168.0.22 | GET      "/health"
2026/06/11 05:21:36 http: TLS handshake error from 192.168.0.22:34060: EOF 
```

What's done:
1. Use `httpGet` with `/health/live` for liveness probe instead of `tcpSocket`.
2. Replace `/health` to `/health/ready` for readiness probe.
3. Remove `tcpSocket` readiness check for indices cleaner.

## Related Tickets & Documents

- Related Issue: CPCAP-10481