### PR TITLE
fix: Replace deprecated Requests library API

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/netcracker/qubership-docker-integration-tests:main
+FROM ghcr.io/netcracker/qubership-docker-integration-tests:0.5.5
 
 USER root
 

--- a/integration-tests/robot/tests/opensearch/authentication/authentication.robot
+++ b/integration-tests/robot/tests/opensearch/authentication/authentication.robot
@@ -16,7 +16,7 @@ Resource  ../shared/keywords.robot
 *** Keywords ***
 Send Request With Basic Authentication
     [Arguments]  ${path}
-    ${response}=  Get Request  opensearch  ${path}
+    ${response}=  GET On Session  opensearch  ${path}  expected_status=any
     RETURN  ${response}
 
 Register New Client
@@ -33,7 +33,7 @@ Get New Token
 Send Request With OAuth Token
     [Arguments]  ${endpoint}  ${token}  ${data}=${None}
     &{headers}=  Create Dictionary  Authorization=Bearer ${token}
-    ${response}=  Get Request  opensearch  ${endpoint}  headers=${headers}
+    ${response}=  GET On Session  opensearch  ${endpoint}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 *** Test Cases ***

--- a/integration-tests/robot/tests/opensearch/backup/backup.robot
+++ b/integration-tests/robot/tests/opensearch/backup/backup.robot
@@ -77,5 +77,4 @@ Unauthorized Access
     [Tags]  opensearch  backup  unauthorized_access
     Create Session  curator_unauthorized  ${OPENSEARCH_CURATOR_PROTOCOL}://${OPENSEARCH_CURATOR_HOST}:${OPENSEARCH_CURATOR_PORT}
     ...  disable_warnings=1
-    ${response}=  Post Request  curator_unauthorized  /backup
-    Should Be Equal As Strings  ${response.status_code}  401
+    ${response}=  POST On Session  curator_unauthorized  /backup  expected_status=401

--- a/integration-tests/robot/tests/opensearch/backup/backup_databases.robot
+++ b/integration-tests/robot/tests/opensearch/backup/backup_databases.robot
@@ -76,36 +76,33 @@ Generate And Add Unique Data To Index By Id
 Granular Backup
     [Arguments]  ${databases}
     ${data}=  Set Variable  {"dbs":${databases}}
-    ${response}=  Post Request  curatorsession  /backup  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /backup  data=${data}  headers=${headers}
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Backup Status  ${response.content}
     RETURN  ${response.text}
 
 Check Backup Status
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  curatorsession  /jobstatus/${backup_id}
+    ${response}=  GET On Session  curatorsession  /jobstatus/${backup_id}
     ${content}=  Convert Json ${response.content} To Type
     Should Be Equal As Strings  ${content['status']}  Successful
 
 Granular Restore
     [Arguments]  ${backup_id}  ${dbs_list}  ${renames}={}  ${clean}=false
     ${restore_data}=  Set Variable  {"vault":"${backup_id}","dbs":${dbs_list},"changeDbNames":${renames},"custom_vars":{"clean":"${clean}"}}
-    ${response}=  Post Request  curatorsession  /restore  data=${restore_data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /restore  data=${restore_data}  headers=${headers}
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Restore Status  ${response.content}
 
 Check Restore Status
     [Arguments]  ${task_id}
-    ${response}=  Get Request  curatorsession  /jobstatus/${task_id}
+    ${response}=  GET On Session  curatorsession  /jobstatus/${task_id}
     ${content}=  Convert Json ${response.content} To Type
     Should Be Equal As Strings  ${content['status']}  Successful
 
 Delete Backup
     [Arguments]  ${backup_id}
-    ${response}=  Post Request  curatorsession  /evict/${backup_id}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /evict/${backup_id}
 
 *** Test Cases ***
 Granular Backup And Restore With Alias

--- a/integration-tests/robot/tests/opensearch/backup/backup_keywords.robot
+++ b/integration-tests/robot/tests/opensearch/backup/backup_keywords.robot
@@ -32,8 +32,7 @@ Delete Data
     ...  Check OpenSearch Index Does Not Exist  ${prefix}-2
 
 Full Backup
-    ${response}=  Post Request  curatorsession  /backup
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /backup
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Backup Status  ${response.content}
     RETURN  ${response.text}
@@ -41,75 +40,67 @@ Full Backup
 Granular Backup
     [Arguments]  ${indices_list}
     ${data}=  Set Variable  {"dbs":${indices_list}}
-    ${response}=  Post Request  curatorsession  /backup  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /backup  data=${data}  headers=${headers}
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Backup Status  ${response.content}
     RETURN  ${response.text}
 
 Delete Backup
     [Arguments]  ${backup_id}
-    ${response}=  Post Request  curatorsession  /evict/${backup_id}
-    Should Be Equal As Strings  ${response.status_code}  200
+    POST On Session  curatorsession  /evict/${backup_id}
 
 Delete Backup If Exists
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  curatorsession  /listbackups/${backup_id}
+    ${response}=  GET On Session  curatorsession  /listbackups/${backup_id}  expected_status=any
     Run Keyword If    ${response.status_code}==200    Delete Backup  ${backup_id}
 
 Full Restore
     [Arguments]  ${backup_id}  ${indices_list}
     ${restore_data}=  Set Variable  {"vault":"${backup_id}","dbs":${indices_list}}
-    ${response}=  Post Request  curatorsession  /restore  data=${restore_data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /restore  data=${restore_data}  headers=${headers}
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Restore Status  ${response.content}
 
 Full Restore By Timestamp
     [Arguments]  ${backup_ts}  ${indices_list}
     ${restore_data}=  Set Variable  {"ts":"${backup_ts}","dbs":${indices_list}}
-    ${response}=  Post Request  curatorsession  /restore  data=${restore_data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  curatorsession  /restore  data=${restore_data}  headers=${headers}
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Restore Status  ${response.content}
 
 Get Backup Timestamp
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  curatorsession  /listbackups/${backup_id}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  GET On Session  curatorsession  /listbackups/${backup_id}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content['ts']}
 
 Find Backup ID By Timestamp
     [Arguments]  ${backup_ts}
     ${find_data}=  Set Variable  {"ts":"${backup_ts}"}
-    ${response}=  Get Request  curatorsession  /find  data=${find_data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  GET On Session  curatorsession  /find  data=${find_data}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content['id']}
 
 Check Backup Status
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  curatorsession  /jobstatus/${backup_id}
+    ${response}=  GET On Session  curatorsession  /jobstatus/${backup_id}
     ${content}=  Convert Json ${response.content} To Type
     Should Be Equal As Strings  ${content['status']}  Successful
 
 Check Restore Status
     [Arguments]  ${task_id}
-    ${response}=  Get Request  curatorsession  /jobstatus/${task_id}
+    ${response}=  GET On Session  curatorsession  /jobstatus/${task_id}
     ${content}=  Convert Json ${response.content} To Type
     Should Be Equal As Strings  ${content['status']}  Successful
 
 Check Backup Absence By Curator
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  curatorsession  /listbackups/${backup_id}
-    Should Be Equal As Strings  ${response.status_code}  404
+    ${response}=  GET On Session  curatorsession  /listbackups/${backup_id}  expected_status=404
 
 Check Backup Absence By OpenSearch
     [Arguments]  ${backup_id}
     ${backup_id_in_lowercase}=  Convert To Lowercase  ${backup_id}
-    ${response}=  Get Request  opensearch  /_snapshot/snapshots/${backup_id_in_lowercase}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  404
+    ${response}=  GET On Session  opensearch  /_snapshot/snapshots/${backup_id_in_lowercase}  headers=${headers}  expected_status=404
 
 Create Index With Generated Data
     [Arguments]  ${index_name}

--- a/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_backup.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_backup.robot
@@ -35,7 +35,7 @@ Generate Name
 
 Create Backup By Dbaas Agent
     [Arguments]  ${indices_list}
-    ${response}=  Post Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/collect  data=${indices_list}  headers=${headers}
+    ${response}=  POST On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/collect  data=${indices_list}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Backup Status  ${content['trackId']}
@@ -43,30 +43,28 @@ Create Backup By Dbaas Agent
 
 Delete Backup By Dbaas Agent
     [Arguments]  ${backup_id}
-    ${response}=  Delete Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/${backup_id}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    DELETE On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/${backup_id}  headers=${headers}
 
 Restore Indices From Backup By Dbaas Agent
     [Arguments]  ${backup_id}  ${indices_list}
-    ${response}=  Post Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/${backup_id}/restore  data=${indices_list}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/${backup_id}/restore  data=${indices_list}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Restore Status  ${content['trackId']}
 
 Check Backup Status
     [Arguments]  ${backup_id}
-    ${restore_status}=  Get Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/track/backup/${backup_id}
+    ${restore_status}=  GET On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/track/backup/${backup_id}
     Should Contain  str(${restore_status.content})  SUCCESS
 
 Check Restore Status
     [Arguments]  ${backup_id}
-    ${restore_status}=  Get Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/track/restore/${backup_id}
+    ${restore_status}=  GET On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/backups/track/restore/${backup_id}
     Should Contain  str(${restore_status.content})  SUCCESS
 
 Delete OpenSearch Backup
     [Arguments]  ${backup_id}
-    ${response}=  Delete Request  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${backup_id}
+    ${response}=  DELETE On Session  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${backup_id}  expected_status=any
     ${boolean_success_result}=  Evaluate  ${response.status_code} in [200, 404]
     Should Be True  ${boolean_success_result}
 
@@ -75,13 +73,11 @@ Check OpenSearch Backup Exists
     # DBaaS adapter manipulates backups via Curator.
     # The backup_id in backup-daemon and the real snapshot name in opensearch are different.
     ${opensearch_backup_id}=  Convert To Lowercase  ${backup_id}
-    ${response}=  Get Request  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${opensearch_backup_id}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  GET On Session  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${opensearch_backup_id}
 
 Check OpenSearch Backup Does Not Exist
     [Arguments]  ${backup_id}
-    ${response}=  Get Request  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${backup_id}
-    Should Be Equal As Strings  ${response.status_code}  404
+    GET On Session  opensearch  /_snapshot/${OPENSEARCH_DBAAS_ADAPTER_REPOSITORY}/${backup_id}  expected_status=404
 
 *** Test Cases ***
 Create Backup By Dbaas Adapter

--- a/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_index.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_index.robot
@@ -32,15 +32,13 @@ Prepare Dbaas Adapter
 Create Index By Dbaas Agent
     [Arguments]  ${prefix}  ${db_name}  ${username}=  ${password}=
     ${data}=  Set Variable  {"dbName":"${db_name}","metadata":{},"settings":{"index":{"number_of_shards":3,"number_of_replicas":1}},"namePrefix":"${prefix}","username":"${username}","password":"${password}"}
-    ${response}=  Post Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/databases  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  201
+    ${response}=  POST On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/databases  data=${data}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
 Delete Resources By Dbaas Agent
     [Arguments]  ${data}
-    ${response}=  Post Request  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/resources/bulk-drop  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    POST On Session  dbaassession  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/resources/bulk-drop  data=${data}  headers=${headers}
 
 *** Test Cases ***
 Create Index By Dbaas Adapter

--- a/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_ism.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_ism.robot
@@ -10,8 +10,7 @@ Suite Setup  Prepare
 Set ISM Job Interval
     [Arguments]  ${interval}
     Login To OpenSearch  ${OPENSEARCH_USERNAME}  ${OPENSEARCH_PASSWORD}
-    ${response}=  Update Cluster Settings  {"persistent" : {"plugins.index_state_management.job_interval": ${interval}}}
-    Should Be Equal As Strings  ${response.status_code}  200
+    Update Cluster Settings  {"persistent" : {"plugins.index_state_management.job_interval": ${interval}}}
 
 Check Managed Index State
     [Arguments]  ${index_name}  ${policy_name}  ${state}

--- a/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_resource_prefix.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_resource_prefix.robot
@@ -12,8 +12,7 @@ Suite Setup  Prepare
 Change User Password By Dbaas Agent
     [Arguments]  ${username}  ${password}  ${role_type}
     ${data}=  Set Variable  {"password": "${password}", "role": "${role_type}"}
-    ${response}=  Put Request  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/users/${username}  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  201
+    ${response}=  PUT On Session  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/users/${username}  data=${data}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
@@ -88,8 +87,7 @@ Database Resource Prefix Authorization
     Should Be Equal As Strings  ${response.status_code}  403
     ${document}=  Set Variable  {"name": "John", "age": "25"}
     Create Document ${document} For Index ${resourcePrefix_first}-test
-    ${response}=  Make Index Read Only  ${resourcePrefix_first}-test
-    Should Be Equal As Strings  ${response.status_code}  200
+    Make Index Read Only  ${resourcePrefix_first}-test
     ${response}=  Clone Index  ${resourcePrefix_first}-test  ${resourcePrefix_first}-test-new
     Should Be Equal As Strings  ${response.status_code}  200
     Check OpenSearch Index Exists  ${resourcePrefix_first}-test-new
@@ -98,8 +96,7 @@ Database Resource Prefix Authorization
 #    {response}=  Clone Index  ${resourcePrefix_first}-test  custom-test-new
 #    Should Be Equal As Strings  ${response.status_code}  403
 
-    ${response}=  Make Index Read Write  ${resourcePrefix_first}-test
-    Should Be Equal As Strings  ${response.status_code}  200
+    Make Index Read Write  ${resourcePrefix_first}-test
 
     Login To OpenSearch  ${username_second}  ${password_second}
     Create OpenSearch Template  ${resourcePrefix_second}-template  ${resourcePrefix_second}*  {"number_of_shards":3}
@@ -108,8 +105,7 @@ Database Resource Prefix Authorization
     Should Be Equal As Strings  ${response.status_code}  200
     ${response}=  Create OpenSearch Index  ${resourcePrefix_first}-test2
     Should Be Equal As Strings  ${response.status_code}  403
-    ${response}=  Get Request  opensearch  /${resourcePrefix_first}-test/_search
-    Should Be Equal As Strings  ${response.status_code}  403
+    ${response}=  GET On Session  opensearch  /${resourcePrefix_first}-test/_search  expected_status=403
     ${document}=  Set Variable  {"name": "John", "age": "26"}
     ${response}=  Update Document ${document} For Index ${resourcePrefix_first}-test
     Should Be Equal As Strings  ${response.status_code}  403

--- a/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_users_recovery.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/dbaas_adapter_users_recovery.robot
@@ -17,12 +17,10 @@ Suite Setup  Prepare
 Run Users Recovery By Dbaas Agent
     [Arguments]  ${properties}
     ${data}=  Set Variable  {"settings": {}, "connectionProperties": ${properties}}
-    ${response}=  Post Request  dbaas_admin_session  api/v2/dbaas/adapter/opensearch/users/restore-password  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  dbaas_admin_session  /api/v2/dbaas/adapter/opensearch/users/restore-password  data=${data}  headers=${headers}
 
 Get Users Recovery State By Dbaas Agent
-    ${response}=  Get Request  dbaas_admin_session  api/v2/dbaas/adapter/opensearch/users/restore-password/state  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  GET On Session  dbaas_admin_session  /api/v2/dbaas/adapter/opensearch/users/restore-password/state  headers=${headers}
     RETURN  ${response.content}
 
 Check Users Recovery State

--- a/integration-tests/robot/tests/opensearch/dbaas/keywords.robot
+++ b/integration-tests/robot/tests/opensearch/dbaas/keywords.robot
@@ -35,13 +35,11 @@ Create Database Resource Prefix By Dbaas Agent
     &{data}=  Create Dictionary  settings=${settings}
     Run Keyword If  "${prefix}" != "${EMPTY}"  Set To Dictionary  ${data}  namePrefix=${prefix}
     Run Keyword If  ${metadata}  Set To Dictionary  ${data}  metadata=${metadata}
-    ${response}=  Post Request  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/databases  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  201
+    ${response}=  POST On Session  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/databases  json=${data}  headers=${headers}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
 Delete Database Resource Prefix Dbaas Agent
     [Arguments]  ${prefix}
     ${data}=  Set Variable  [{"kind":"resourcePrefix","name":"${prefix}"}]
-    ${response}=  Post Request  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/resources/bulk-drop  data=${data}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  POST On Session  dbaas_admin_session  /api/${OPENSEARCH_DBAAS_ADAPTER_API_VERSION}/dbaas/adapter/${DBAAS_ADAPTER_TYPE}/resources/bulk-drop  data=${data}  headers=${headers}

--- a/integration-tests/robot/tests/opensearch/shared/keywords.robot
+++ b/integration-tests/robot/tests/opensearch/shared/keywords.robot
@@ -52,19 +52,18 @@ Generate Database Name
 
 Create OpenSearch Index
     [Arguments]  ${name}  ${data}=${None}
-    ${json}=  Run Keyword If  ${data}  To Json  ${data}
-    ${response}=  Put Request  opensearch  /${name}  data=${json}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /${name}  data=${data}  headers=${headers}  expected_status=any
     Log  ${response.content}
     RETURN  ${response}
 
 Get OpenSearch Index
     [Arguments]  ${name}  ${timeout}=${None}
-    ${response}=  Get Request  opensearch  /${name}  timeout=${timeout}
+    ${response}=  GET On Session  opensearch  /${name}  timeout=${timeout}  expected_status=any
     RETURN  ${response}
 
 Delete OpenSearch Index
     [Arguments]  ${name}
-    ${response}=  Delete Request  opensearch  /${name}
+    ${response}=  DELETE On Session  opensearch  /${name}  expected_status=any
     RETURN  ${response}
 
 Check OpenSearch Index Exists
@@ -89,13 +88,13 @@ Check Response Is Empty
 Bulk Update Index Data
     [Arguments]  ${index_name}  ${binary_data}  ${timeout}=${None}
     &{local_headers}=  Create Dictionary  Content-Type=application/x-ndjson
-    ${response}=  Post Request  opensearch  /${index_name}/_bulk  data=${binary_data}  headers=${local_headers}  timeout=${timeout}
+    ${response}=  POST On Session  opensearch  /${index_name}/_bulk  data=${binary_data}  headers=${local_headers}  timeout=${timeout}
     RETURN  ${response}
 
 Bulk Update Data
     [Arguments]  ${binary_data}  ${timeout}=${None}
     &{local_headers}=  Create Dictionary  Content-Type=application/x-ndjson
-    ${response}=  Post Request  opensearch  /_bulk  data=${binary_data}  headers=${local_headers}  timeout=${timeout}
+    ${response}=  POST On Session  opensearch  /_bulk  data=${binary_data}  headers=${local_headers}  timeout=${timeout}
     RETURN  ${response}
 
 Create Document ${document} For Index ${index_name}
@@ -103,23 +102,22 @@ Create Document ${document} For Index ${index_name}
 
 Add Document To Index By Id
     [Arguments]  ${index_name}  ${document}  ${id}
-    ${response}=  Put Request  opensearch  /${index_name}/_create/${id}  data=${document}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /${index_name}/_create/${id}  data=${document}  headers=${headers}
     Log  ${response.content}
-    Should Be Equal As Strings  ${response.status_code}  201
 
 Update Document ${document} For Index ${index_name}
     ${document}=  Set Variable  {"doc":${document}}
-    ${response}=  Post Request  opensearch  /${index_name}/_update/1  data=${document}  headers=${headers}
+    ${response}=  POST On Session  opensearch  /${index_name}/_update/1  data=${document}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Search Document
     [Arguments]  ${index_name}  ${timeout}=${None}
-    ${response}=  Get Request  opensearch  /${index_name}/_search  timeout=${timeout}
+    ${response}=  GET On Session  opensearch  /${index_name}/_search  timeout=${timeout}
     RETURN  ${response.content}
 
 Search Document By Field
     [Arguments]  ${index_name}  ${field_name}  ${field_value}
-    ${response}=  Get Request  opensearch  /${index_name}/_search?q=${field_name}:${field_value}
+    ${response}=  GET On Session  opensearch  /${index_name}/_search  params=q=${field_name}:${field_value}
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
@@ -143,15 +141,14 @@ Delete Document For Index ${index_name}
 
 Delete Document From Index By Id
     [Arguments]  ${index_name}  ${id}
-    ${response}=  Delete Request  opensearch  /${index_name}/_doc/${id}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    DELETE On Session  opensearch  /${index_name}/_doc/${id}  headers=${headers}
 
 Convert Json ${json} To Type
     ${json_dictionary}=  Evaluate  json.loads('''${json}''')  json
     RETURN  ${json_dictionary}
 
 Get OpenSearch Status
-    ${response}=  Get Request  opensearch  _cat/health?h=status
+    ${response}=  GET On Session  opensearch  /_cat/health  params=h=status
     ${content}=  Decode Bytes To String  ${response.content}  UTF-8
     RETURN  ${content.strip()}
 
@@ -161,102 +158,99 @@ Check OpenSearch Is Green
 
 Get Index Uuid
     [Arguments]  ${index_name}
-    ${response}=  Get Request  opensearch  _cat/indices/${index_name}?h=uuid
+    ${response}=  GET On Session  opensearch  /_cat/indices/${index_name}  params=h=uuid
     ${content}=  Decode Bytes To String  ${response.content}  UTF-8
     RETURN  ${content.strip()}
 
 Get Index Information
     [Arguments]  ${index_name}
-    ${response}=  Get Request  opensearch  _cat/shards/${index_name}?v&h=shard,prirep,node&format=json
+    ${response}=  GET On Session  opensearch  /_cat/shards/${index_name}  params=v&h=shard,prirep,node&format=json
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
 Get Master Node Name
-    ${response}=  Get Request  opensearch  _cat/cluster_manager?h=node  timeout=10
+    ${response}=  GET On Session  opensearch  /_cat/cluster_manager  params=h=node  timeout=10  expected_status=any
     ${content}=  Decode Bytes To String  ${response.content}  UTF-8
     Should Be Equal As Strings  ${response.status_code}  200  OpenSearch returned ${response.status_code} code. Master node is not recognized
     RETURN  ${content.strip()}
 
 Create OpenSearch Alias
     [Arguments]  ${index_name}  ${alias}
-    ${response}=  Put Request  opensearch  /${index_name}/_alias/${alias}
+    ${response}=  PUT On Session  opensearch  /${index_name}/_alias/${alias}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Alias
     [Arguments]  ${alias}
-    ${response}=  Get Request  opensearch  /_alias/${alias}
+    ${response}=  GET On Session  opensearch  /_alias/${alias}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Alias For Index
     [Arguments]  ${index_name}  ${alias}
-    ${response}=  Get Request  opensearch  /${index_name}/_alias/${alias}
+    ${response}=  GET On Session  opensearch  /${index_name}/_alias/${alias}  expected_status=any
     RETURN  ${response}
 
 Create OpenSearch Component Template
     [Arguments]  ${template_name}  ${settings}={}  ${aliases}={}
     ${template}=  Set Variable  {"template": {"settings":${settings}, "aliases": ${aliases}}}
-    ${response}=  Put Request  opensearch  /_component_template/${template_name}  data=${template}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  PUT On Session  opensearch  /_component_template/${template_name}  data=${template}  headers=${headers}
 
 Create OpenSearch Index Template
     [Arguments]  ${template_name}  ${index_pattern}  ${settings}={}  ${aliases}={}  ${composed_of}=[]
     ${template}=  Set Variable  {"index_patterns":["${index_pattern}"],"template": {"settings":${settings}, "aliases": ${aliases}}, "composed_of": ${composed_of}}
-    ${response}=  Put Request  opensearch  /_index_template/${template_name}  data=${template}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  PUT On Session  opensearch  /_index_template/${template_name}  data=${template}  headers=${headers}
 
 Create OpenSearch Template
     [Arguments]  ${template_name}  ${index_pattern}  ${settings}={}  ${aliases}={}
     ${template}=  Set Variable  {"index_patterns":["${index_pattern}"],"settings":${settings},"aliases": ${aliases}}
-    ${response}=  Put Request  opensearch  /_template/${template_name}  data=${template}  headers=${headers}
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  PUT On Session  opensearch  /_template/${template_name}  data=${template}  headers=${headers}
 
 Get OpenSearch Template
     [Arguments]  ${template_name}
-    ${response}=  Get Request  opensearch  /_template/${template_name}
+    ${response}=  GET On Session  opensearch  /_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Delete OpenSearch Template
     [Arguments]  ${template_name}
-    ${response}=  Delete Request  opensearch  /_template/${template_name}
+    ${response}=  DELETE On Session  opensearch  /_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Component Template
     [Arguments]  ${template_name}
-    ${response}=  Get Request  opensearch  /_component_template/${template_name}
+    ${response}=  GET On Session  opensearch  /_component_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Delete OpenSearch Component Template
     [Arguments]  ${template_name}
-    ${response}=  Delete Request  opensearch  /_component_template/${template_name}
+    ${response}=  DELETE On Session  opensearch  /_component_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Index Template
     [Arguments]  ${template_name}
-    ${response}=  Get Request  opensearch  /_index_template/${template_name}
+    ${response}=  GET On Session  opensearch  /_index_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Delete OpenSearch Index Template
     [Arguments]  ${template_name}
-    ${response}=  Delete Request  opensearch  /_index_template/${template_name}
+    ${response}=  DELETE On Session  opensearch  /_index_template/${template_name}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Tasks
-    ${response}=  Get Request  opensearch  /_tasks
+    ${response}=  GET On Session  opensearch  /_tasks  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Task By ID
     [Arguments]  ${task_id}
-    ${response}=  Get Request  opensearch  /_tasks/${task_id}
+    ${response}=  GET On Session  opensearch  /_tasks/${task_id}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch Index Exists
     [Arguments]  ${index_name}
-    ${response}=  Head Request  opensearch  /${index_name}
+    ${response}=  HEAD On Session  opensearch  /${index_name}  expected_status=any
     RETURN  ${response}
 
 Get OpenSearch User
     [Arguments]  ${username}
-    ${response}=  Get Request  opensearch  /_plugins/_security/api/internalusers/${username}
+    ${response}=  GET On Session  opensearch  /_plugins/_security/api/internalusers/${username}  expected_status=any
     RETURN  ${response}
 
 Check OpenSearch User Exists
@@ -266,91 +260,89 @@ Check OpenSearch User Exists
 
 Get Index Settings
     [Arguments]  ${index_name}
-    ${response}=  Get Request  opensearch  /${index_name}/_settings
-    Should Be Equal As Strings  ${response.status_code}  200
+    ${response}=  GET On Session  opensearch  /${index_name}/_settings
     ${content}=  Convert Json ${response.content} To Type
     RETURN  ${content}
 
 Make Index Read Only
     [Arguments]  ${index_name}
     ${body}=  Set Variable  {"settings":{"index.blocks.write":true}}
-    ${response}=  Put Request  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
-    RETURN  ${response}
+    PUT On Session  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
 
 Make Index Read Write
     [Arguments]  ${index_name}
     ${body}=  Set Variable  {"settings":{"index.blocks.write":false}}
-    ${response}=  Put Request  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
     RETURN  ${response}
 
 Enable Slow Log
     [Arguments]  ${index_name}
     ${body}=  Set Variable  {"search":{"slowlog":{"threshold":{"query":{"info":"0s"}}}}}
-    ${response}=  Put Request  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /${index_name}/_settings  data=${body}  headers=${headers}
     RETURN  ${response}
 
 Clone Index
     [Arguments]  ${index_name}  ${clone_index_name}
-    ${response}=  Put Request  opensearch  /${index_name}/_clone/${clone_index_name}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /${index_name}/_clone/${clone_index_name}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Create Policy
     [Arguments]  ${policy_name}  ${body}
-    ${response}=  Put Request  opensearch  _plugins/_ism/policies/${policy_name}  data=${body}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /_plugins/_ism/policies/${policy_name}  data=${body}  headers=${headers}  expected_status=any
     Log  ${response.text}
     RETURN  ${response}
 
 Get Policy
     [Arguments]  ${policy_name}  ${with_content}=True
-    ${response}=  Get Request  opensearch  _plugins/_ism/policies/${policy_name}
+    ${response}=  GET On Session  opensearch  /_plugins/_ism/policies/${policy_name}  expected_status=any
     Log  ${response.text}
     Run Keyword And Return If  ${with_content}  Get Response Content  ${response}
     RETURN  ${response}
 
 Get Policies
-    ${response}=  Get Request  opensearch  _plugins/_ism/policies
+    ${response}=  GET On Session  opensearch  /_plugins/_ism/policies
     RETURN  ${response}
 
 Update Policy
     [Arguments]  ${policy_name}  ${seq_no}  ${primary_term}  ${body}
-    ${response}=  Put Request  opensearch  _plugins/_ism/policies/${policy_name}?if_seq_no=${seq_no}&if_primary_term=${primary_term}  data=${body}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /_plugins/_ism/policies/${policy_name}  params=if_seq_no=${seq_no}&if_primary_term=${primary_term}  data=${body}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Remove Policy
     [Arguments]  ${policy_name}
-    ${response}=  Delete Request  opensearch  _plugins/_ism/policies/${policy_name}  headers=${headers}
+    ${response}=  DELETE On Session  opensearch  /_plugins/_ism/policies/${policy_name}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Add Policy To Index
     [Arguments]  ${index_name}  ${policy_name}
-    ${response}=  Post Request  opensearch  _plugins/_ism/add/${index_name}  data={"policy_id": "${policy_name}"}  headers=${headers}
+    ${response}=  POST On Session  opensearch  /_plugins/_ism/add/${index_name}  data={"policy_id": "${policy_name}"}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Explain Index
     [Arguments]  ${index_name}  ${with_content}=True
-    ${response}=  Get Request  opensearch  _plugins/_ism/explain/${index_name}
+    ${response}=  GET On Session  opensearch  /_plugins/_ism/explain/${index_name}  expected_status=any
     Log  ${response.text}
     Run Keyword And Return If  ${with_content}  Get Response Content  ${response}
     RETURN  ${response}
 
 Change Index Policy
     [Arguments]  ${index_name}  ${data}
-    ${response}=  Post Request  opensearch  _plugins/_ism/change_policy/${index_name}  data=${data}  headers=${headers}
+    ${response}=  POST On Session  opensearch  /_plugins/_ism/change_policy/${index_name}  data=${data}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Retry Failed Index
     [Arguments]  ${index_name}  ${data}
-    ${response}=  Post Request  opensearch  _plugins/_ism/retry/${index_name}  data=${data}  headers=${headers}
+    ${response}=  POST On Session  opensearch  /_plugins/_ism/retry/${index_name}  data=${data}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Remove Policy From Index
     [Arguments]  ${index_name}
-    ${response}=  Post Request  opensearch  _plugins/_ism/remove/${index_name}  headers=${headers}
+    ${response}=  POST On Session  opensearch  /_plugins/_ism/remove/${index_name}  headers=${headers}  expected_status=any
     RETURN  ${response}
 
 Update Cluster Settings
     [Arguments]  ${body}
-    ${response}=  Put Request  opensearch  _cluster/settings  data=${body}  headers=${headers}
+    ${response}=  PUT On Session  opensearch  /_cluster/settings  data=${body}  headers=${headers}
     RETURN  ${response}
 
 Get Response Content


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Integration tests logs are full of deprecation messages:
```
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
Find Backup By Timestamp                                              | PASS |
------------------------------------------------------------------------------
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
Granular Backup And Restore                                           | PASS |
------------------------------------------------------------------------------
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
Granular Backup And Restore By Timestamp                              | PASS |
------------------------------------------------------------------------------
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Put Request' is deprecated. Please use `PUT On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
Delete Backup By ID                                                   | PASS |
------------------------------------------------------------------------------
[ WARN ] Keyword 'RequestsLibrary.Post Request' is deprecated. Please use `POST On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Delete Request' is deprecated. Please use `DELETE On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
[ WARN ] Keyword 'RequestsLibrary.Get Request' is deprecated. Please use `GET On Session` instead.
Unauthorized Access                                                   | PASS |
```

What's done:

0. Replaced deprecated `requests` API (`Get Request`, `Post Request`, etc.) to new one (`GET On Session`, `POST On Session`, etc.).
1. Added missing '/' for URL in requests.
2. Added `params=` property for URLs with parameters.
3. Added `expected_status=any` property for requests where we check status explicitly.
4. Replaced `To Json  ${data}` with `${data.json()}`.
5. Actualized JSON configuration for index creation.

## Related Tickets & Documents

- Related Issue - CPCAP-1489