### PR TITLE
fix: exclude 'top_queries' from inappropriate indices collection in m…

### DIFF
--- a/curator/docker/backup-docker/indices_migration_tool/main.go
+++ b/curator/docker/backup-docker/indices_migration_tool/main.go
@@ -294,7 +294,7 @@ func (m *MigrationTool) CollectInappropriateIndices(ctx context.Context) ([]stri
 			continue
 		}
 		oneXAll = append(oneXAll, idx)
-		if !strings.HasPrefix(idx, ".") {
+		if !strings.HasPrefix(idx, ".") && !strings.HasPrefix(idx, "top_queries") {
 			oneXBackup = append(oneXBackup, idx)
 		}
 	}


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request makes a targeted adjustment to the index collection logic in the `MigrationTool`. The main change is to exclude indices starting with `top_queries` from being added to the backup list, in addition to those starting with a dot.

Index filtering update:

* Updated the condition in `CollectInappropriateIndices` (`main.go`) to skip indices with names starting with `top_queries` when populating the `oneXBackup` list.
## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue CPCAP-11596
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
