### PR TITLE
fix: Use `Recreate` strategy for operator and integration tests

### DIFF
--- a/operator/charts/helm/opensearch-service/templates/integration-tests/deployment.yaml
+++ b/operator/charts/helm/opensearch-service/templates/integration-tests/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       name: {{ template "opensearch.fullname" . }}-integration-tests
   strategy:
-    type: RollingUpdate
+    type: Recreate
   replicas: {{ template "opensearch.replicasForSingleService" . }}
   progressDeadlineSeconds: {{ .Values.statusProvisioner.integrationTestsTimeout | default 300 }}
   template:

--- a/operator/charts/helm/opensearch-service/templates/operator/deployment.yaml
+++ b/operator/charts/helm/opensearch-service/templates/operator/deployment.yaml
@@ -15,6 +15,8 @@ spec:
     matchLabels:
       name: {{ template "opensearch.fullname" . }}-service-operator
       component: opensearch-service-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Thera two operator/tests pods during upgrade because of `RollingUpdate` strategy:
```
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 25%
      maxSurge: 25%
```

What's done:
1. For operator and tests deployments `Recreate` strategy is used:
```
  strategy:
    type: Recreate
```

## Related Tickets & Documents

- Related Issue: CPCAP-12188