### PR TITLE
fix: Clear `rollingUpdate` block

### DIFF
--- a/operator/charts/helm/opensearch-service/templates/pre-deploy/resource-migrator-job.yaml
+++ b/operator/charts/helm/opensearch-service/templates/pre-deploy/resource-migrator-job.yaml
@@ -35,6 +35,32 @@ spec:
 
               KUBECTL="kubectl"
               NS="{{ .Release.Namespace }}"
+
+              patch_deployment_strategy() {
+                DEPLOYMENT_NAME="$1"
+                DEPLOYMENT_JSON="$($KUBECTL -n "$NS" get deployment "$DEPLOYMENT_NAME" -o json 2>/dev/null || true)"
+                if [ -z "$DEPLOYMENT_JSON" ]; then
+                  echo "[resource-migrator] Deployment $DEPLOYMENT_NAME does not exist, skipping"
+                  return
+                fi
+                HAS_ROLLING="$(printf '%s' "$DEPLOYMENT_JSON" | jq '.spec.strategy.rollingUpdate != null')"
+                if [ "$HAS_ROLLING" = "true" ]; then
+                  echo "[resource-migrator] Deployment $DEPLOYMENT_NAME has stale rollingUpdate block, patching to Recreate strategy"
+                  if $KUBECTL -n "$NS" patch deployment "$DEPLOYMENT_NAME" \
+                      --type=json -p='[{"op":"replace","path":"/spec/strategy/type","value":"Recreate"},{"op":"remove","path":"/spec/strategy/rollingUpdate"}]'; then
+                    echo "[resource-migrator] Deployment $DEPLOYMENT_NAME patched successfully"
+                  else
+                    echo "[resource-migrator][ERROR] Failed to patch deployment $DEPLOYMENT_NAME"
+                    exit 1
+                  fi
+                else
+                  echo "[resource-migrator] Deployment $DEPLOYMENT_NAME: no rollingUpdate block, skipping"
+                fi
+              }
+
+              patch_deployment_strategy "{{ template "opensearch.fullname" . }}-service-operator"
+              patch_deployment_strategy "{{ template "opensearch.fullname" . }}-integration-tests"
+
               STATEFULSET_NAMES="{{ trim (include "opensearch.statefulsetNames" .) }}"
 
               if [ -z "$STATEFULSET_NAMES" ]; then

--- a/operator/charts/helm/opensearch-service/templates/pre-deploy/resource-migrator-rbac.yaml
+++ b/operator/charts/helm/opensearch-service/templates/pre-deploy/resource-migrator-rbac.yaml
@@ -13,6 +13,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get","list","delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get","patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

ArgoCD upgrade from previous version fails with the following logs:
```
INFO [2026-07-26 20:14:23,136] 	   - Deployment/opensearch-service-operator; Sync: SyncFailed; Phase: Failed
INFO [2026-07-26 20:14:23,136] 	     Sync Message: Deployment.apps "opensearch-service-operator" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
INFO [2026-07-26 20:14:23,136] 	   - Deployment/opensearch-integration-tests; Sync: SyncFailed; Phase: Failed
INFO [2026-07-26 20:14:23,136] 	     Sync Message: Deployment.apps "opensearch-integration-tests" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

What's done:
1. Patch `operator` and `integration-test` deployments strategy with `Recreate` type and `null` `rollingUpdate` section.
2. Add corresponding grants for `resource-migrator` role.

Logs in  `resource-migrator` job:
```
[resource-migrator] Deployment opensearch-service-operator has stale rollingUpdate block, patching to Recreate strategy
deployment.apps/opensearch-service-operator patched
[resource-migrator] Deployment opensearch-service-operator patched successfully
[resource-migrator] Deployment opensearch-integration-tests has stale rollingUpdate block, patching to Recreate strategy
deployment.apps/opensearch-integration-tests patched
[resource-migrator] Deployment opensearch-integration-tests patched successfully
[resource-migrator] StatefulSet opensearch: no 'node.master' env found, skipping
[resource-migrator] done
```

## Related Tickets & Documents

- Related Issue: CPCAP-12188